### PR TITLE
youtube short url 고려하여 videoIdParser 수정

### DIFF
--- a/lib/video.ts
+++ b/lib/video.ts
@@ -6,8 +6,7 @@ export const videoIdParser = (url: string) => {
     } else {
       return url.split('watch?v=')[1];
     }
-  }
-  else if (url.startsWith('https://youtu.be/')) {
+  } else if (url.startsWith('https://youtu.be/')) {
     /** 재생목록 안에 있는 주소 파싱 */
     if (url.includes('&list')) {
       return url.split('&list')[0].split('youtu.be/')[1];

--- a/lib/video.ts
+++ b/lib/video.ts
@@ -7,4 +7,12 @@ export const videoIdParser = (url: string) => {
       return url.split('watch?v=')[1];
     }
   }
+  else if (url.startsWith('https://youtu.be/')) {
+    /** 재생목록 안에 있는 주소 파싱 */
+    if (url.includes('&list')) {
+      return url.split('&list')[0].split('youtu.be/')[1];
+    } else {
+      return url.split('youtu.be/')[1];
+    }
+  }
 };


### PR DESCRIPTION
write 기능 사용 시 short url 형식(https://youtu.be/) 은 파싱 되지 않고 있어 파서를 수정하였습니다.

- short url 형식은 youtube에서 공유 기능을 사용하면 생성됩니다.
- 다른 진입점이 있는지는 확인하지 못했습니다.
- 리스트를 통해 들어간 영상의 경우에도 공유 기능을 통해 생성된 url에는 '&list' 파라메터가 붙지 않습니다.
- 하지만 실제로 파라메터를 붙이면 영상이 정상적으로 보여지므로(해당 url을 얻는 다른 진입점이 있을 수 있어) 기존 로직과 동일하게 '&list'를 고려한 로직을 사용했습니다.
[예시] https://youtu.be/xXWyJEo6VgA&list=RDxXWyJEo6VgA